### PR TITLE
Fixing quantiseqr immunedeconv difference

### DIFF
--- a/R/quantiseqr_helpers.R
+++ b/R/quantiseqr_helpers.R
@@ -429,17 +429,10 @@ mapGenes <- function(mydata) {
   mydata <- mydata[which(!is.na(newgenes)), ]
   newgenes <- newgenes[which(!is.na(newgenes))]
 
-  # Take the median if duplicates are present
-  if (any(duplicated(rownames(mydata)))) {
-    # message("dupe dupes, might take a little longer: maybe work on faster options?")
-    outdata <- aggregate(mydata, by = list(newgenes), FUN = median)
-    rownames(outdata) <- outdata[, 1]
-    outdata <- outdata[, -1, drop = FALSE]
-    outdata <- as.data.frame(outdata)
-  } else {
-    # message("no dupes")
-    outdata <- as.data.frame(mydata)
-  }
+  outdata <- aggregate(mydata, by = list(newgenes), FUN = median)
+  rownames(outdata) <- outdata[, 1]
+  outdata <- outdata[, -1, drop = FALSE]
+  outdata <- as.data.frame(outdata)
 
   return(outdata)
 }

--- a/R/quantiseqr_helpers.R
+++ b/R/quantiseqr_helpers.R
@@ -429,6 +429,7 @@ mapGenes <- function(mydata) {
   mydata <- mydata[which(!is.na(newgenes)), ]
   newgenes <- newgenes[which(!is.na(newgenes))]
 
+  # Take the median if duplicates are present
   outdata <- aggregate(mydata, by = list(newgenes), FUN = median)
   rownames(outdata) <- outdata[, 1]
   outdata <- outdata[, -1, drop = FALSE]


### PR DESCRIPTION
Hi,  i had a deeper look into quantiseqr concerning the small differences between `immunedeconv::deconvolute_quantiseq()` and `quantiseqr::run_quantiseq()`

Main difference: the changed codeblock does contain an `aggregate()` call. In immundeconv this line runs everytime. In quantiseqr it's wrapped in an if statement and therefore only running if the parameters match. 

I am not completely aware what is happening inside `aggregate()` but this can lead to genes missing in the analysis. In my test 4 genes were missing in the quantiseqr run when compared to immundeconv while all parameters where identical.

I adapted the code to match the immunedeconv version. 

I do get that this will be faster when not running `aggregate()` everytime but some genes might be removed.

This is the immunedeconv version: https://github.com/omnideconv/immunedeconv/blob/e5fdf46e5c01a8ac7db011051c58ca9d1d219db8/R/quantiseq_helper.R#L100-L104

Greetings from Innsbruck!